### PR TITLE
Add examples + small refactors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ test_coverage:
 	go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out
 
 example:
-	# Run example with provided API key. Usage: make example api_key=my_test_api_key
+	# Run example with the provided API key. Usage: make example api_key=my_test_api_key
 	API_KEY=$(api_key) go run example/main.go

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ test_coverage:
 	go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out
 
 example:
-	# Run example with provided API key.
+	# Run example with provided API key. Usage: make example api_key=my_test_api_key
 	API_KEY=$(api_key) go run example/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
 
+.PHONY: example
+
 test:
 	# Run tests.
 	go test -race ./...
@@ -7,3 +9,7 @@ test:
 test_coverage:
 	# Run tests and generate coverage profile
 	go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out
+
+example:
+	# Run example with provided API key.
+	API_KEY=$(api_key) go run example/main.go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # go-yelp
 
 Simple go client for the Yelp Fusion (v3) API.
+
+## Examples
+Basic examples can be found [here](/example/main.go#32), which can be used to test
+the client / API locally. The file can be modified to test out other API request
+parameters. The examples can be run with `make`:
+```
+make example api_key=my_api_key
+```

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/alex-chou/go-yelp/yelp"
+)
+
+var (
+	// apiKey as provided by Yelp when an app is created. Can be found here:
+	// https://www.yelp.com/developers/v3/manage_app
+	apiKey string
+
+	// shared client for the example.
+	client yelp.Client
+)
+
+func init() {
+	apiKey = os.Getenv("API_KEY")
+	if apiKey == "" {
+		log.Fatal("`API_KEY` must be specified")
+	}
+	client = yelp.New(http.DefaultClient, apiKey)
+}
+
+// Example usage: `API_KEY=api_key go run example/main.go`
+func main() {
+	ctx := context.Background()
+
+	// Uncomment one to try out the API call.
+	//RunBusinessSearch(ctx)
+	RunGetBusiness(ctx)
+}
+
+// RunBusinessSearch makes a Business Search request.
+func RunBusinessSearch(ctx context.Context) {
+	results, err := client.BusinessSearch(ctx, &yelp.BusinessSearchOptions{
+		Location: yelp.StringPointer("New York"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint(results)
+}
+
+// RunGetBusiness makes a Get Business request.
+func RunGetBusiness(ctx context.Context) {
+	business, err := client.GetBusiness(ctx, &yelp.GetBusinessOptions{
+		ID: "nI1UYDCYUTt23TpGxqnLKg",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	prettyPrint(business)
+}
+
+// prettyPrint prints the input.
+func prettyPrint(v interface{}) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(b))
+}

--- a/yelp/business.go
+++ b/yelp/business.go
@@ -36,12 +36,8 @@ func (gbo *GetBusinessOptions) Validate() error {
 		return errors.New("GetBusinessOptions are unset")
 	case gbo.ID == "":
 		return errors.New("GetBusinessOptions `ID` is not set")
-	case gbo.Locale != nil:
-		if _, ok := ValidLocales[*gbo.Locale]; !ok {
-			return fmt.Errorf("GetBusinessOptions `Locale` is invalid: %s", *gbo.Locale)
-		}
-		// Note: make sure to check other conditions if locale is valid
-		fallthrough
+	case gbo.Locale != nil && ValidateLocale(*gbo.Locale) != nil:
+		return fmt.Errorf("GetBusinessOptions `Locale` is invalid: %s", *gbo.Locale)
 	default:
 		return nil
 	}

--- a/yelp/business.go
+++ b/yelp/business.go
@@ -8,73 +8,10 @@ import (
 	"net/url"
 )
 
-// GetBusiness makes a request given the options provided.
-func (c *client) GetBusiness(ctx context.Context, gbo *GetBusinessOptions) (*Business, error) {
-	if err := gbo.Validate(); err != nil {
-		return nil, err
-	}
-	var respBody Business
-	_, err := c.authedDo(ctx, http.MethodGet, getBusinessPath(gbo), nil, nil, &respBody)
-	return &respBody, err
-}
-
-// getBusinessPath returns the business details path.
-func getBusinessPath(gbo *GetBusinessOptions) string {
-	return fmt.Sprintf("/v3/businesses/%s?%s", gbo.ID, gbo.URLValues().Encode())
-}
-
 // GetBusinessOptions contains the available parameters for the Get Business API.
 type GetBusinessOptions struct {
 	ID     string
 	Locale *string
-}
-
-// Validate returns an error with details when GetBusinessOptions are not valid.
-func (gbo *GetBusinessOptions) Validate() error {
-	switch {
-	case gbo == nil:
-		return errors.New("GetBusinessOptions are unset")
-	case gbo.ID == "":
-		return errors.New("GetBusinessOptions `ID` is not set")
-	case gbo.Locale != nil && ValidateLocale(*gbo.Locale) != nil:
-		return fmt.Errorf("GetBusinessOptions `Locale` is invalid: %s", *gbo.Locale)
-	default:
-		return nil
-	}
-}
-
-// URLValues returns GetBusinessOptions as url.Values.
-func (gbo *GetBusinessOptions) URLValues() url.Values {
-	if gbo == nil {
-		return nil
-	}
-
-	vals := url.Values{}
-	if gbo.Locale != nil {
-		vals.Add("locale", *gbo.Locale)
-	}
-	return vals
-}
-
-// Category describes a business.
-type Category struct {
-	Alias string `json:"alias"`
-	Title string `json:"title"`
-}
-
-// Hours has opening business hours for each day in a week.
-type Hours struct {
-	IsOpenNow bool   `json:"is_open_now"`
-	HoursType string `json:"hours_type"`
-	Open      []Open `json:"open"`
-}
-
-// Open has detailed opening business hours for each day in a week.
-type Open struct {
-	Day         int    `json:"day"`
-	Start       string `json:"start"`
-	End         string `json:"end"`
-	IsOvernight bool   `json:"is_overnight"`
 }
 
 // Business defines a business returned by the Yelp API.
@@ -103,4 +40,67 @@ type Business struct {
 
 	// The fields below are only available for Yelp Fusion VIP clients.
 	Attributes map[string]interface{} `json:"attributes"`
+}
+
+// Category describes a business.
+type Category struct {
+	Alias string `json:"alias"`
+	Title string `json:"title"`
+}
+
+// Hours has opening business hours for each day in a week.
+type Hours struct {
+	IsOpenNow bool   `json:"is_open_now"`
+	HoursType string `json:"hours_type"`
+	Open      []Open `json:"open"`
+}
+
+// Open has detailed opening business hours for each day in a week.
+type Open struct {
+	Day         int    `json:"day"`
+	Start       string `json:"start"`
+	End         string `json:"end"`
+	IsOvernight bool   `json:"is_overnight"`
+}
+
+// GetBusiness makes a request given the options provided.
+func (c *client) GetBusiness(ctx context.Context, gbo *GetBusinessOptions) (*Business, error) {
+	if err := gbo.Validate(); err != nil {
+		return nil, err
+	}
+	var respBody Business
+	_, err := c.authedDo(ctx, http.MethodGet, getBusinessPath(gbo), nil, nil, &respBody)
+	return &respBody, err
+}
+
+// getBusinessPath returns the business details path.
+func getBusinessPath(gbo *GetBusinessOptions) string {
+	return fmt.Sprintf("/v3/businesses/%s?%s", gbo.ID, gbo.URLValues().Encode())
+}
+
+// Validate returns an error with details when GetBusinessOptions are not valid.
+func (gbo *GetBusinessOptions) Validate() error {
+	switch {
+	case gbo == nil:
+		return errors.New("GetBusinessOptions are unset")
+	case gbo.ID == "":
+		return errors.New("GetBusinessOptions `ID` is not set")
+	case gbo.Locale != nil && ValidateLocale(*gbo.Locale) != nil:
+		return fmt.Errorf("GetBusinessOptions `Locale` is invalid: %s", *gbo.Locale)
+	default:
+		return nil
+	}
+}
+
+// URLValues returns GetBusinessOptions as url.Values.
+func (gbo *GetBusinessOptions) URLValues() url.Values {
+	if gbo == nil {
+		return nil
+	}
+
+	vals := url.Values{}
+	if gbo.Locale != nil {
+		vals.Add("locale", *gbo.Locale)
+	}
+	return vals
 }

--- a/yelp/business.go
+++ b/yelp/business.go
@@ -33,13 +33,13 @@ type Business struct {
 	Transactions []string    `json:"transactions"`
 
 	// The fields below are only returned by the Get Business API.
-	Hours     []Hours  `json:"hours"`
-	Alias     *string  `json:"alias"`
-	IsClaimed *bool    `json:"is_claimed"`
-	Photos    []string `json:"photos"`
+	Hours     []Hours  `json:"hours,omitempty"`
+	Alias     *string  `json:"alias,omitempty"`
+	IsClaimed *bool    `json:"is_claimed,omitempty"`
+	Photos    []string `json:"photos,omitempty"`
 
 	// The fields below are only available for Yelp Fusion VIP clients.
-	Attributes map[string]interface{} `json:"attributes"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
 // Category describes a business.

--- a/yelp/business_search.go
+++ b/yelp/business_search.go
@@ -8,21 +8,6 @@ import (
 	"net/url"
 )
 
-// BusinessSearch makes a request given the options provided.
-func (c *client) BusinessSearch(ctx context.Context, bso *BusinessSearchOptions) (*BusinessSearchResults, error) {
-	if err := bso.Validate(); err != nil {
-		return nil, err
-	}
-	var respBody BusinessSearchResults
-	_, err := c.authedDo(ctx, http.MethodGet, businessSearchPath(bso), nil, nil, &respBody)
-	return &respBody, err
-}
-
-// businessSearchPath returns the business search path with parameters.
-func businessSearchPath(bso *BusinessSearchOptions) string {
-	return fmt.Sprintf("/v3/businesses/search?%s", bso.URLValues().Encode())
-}
-
 // BusinessSearchOptions contains the available parameters for the Business Search API.
 type BusinessSearchOptions struct {
 	Term        *string
@@ -45,6 +30,21 @@ type BusinessSearchResults struct {
 	Total      int64      `json:"total"`
 	Businesses []Business `json:"businesses"`
 	Region     Region     `json:"region"`
+}
+
+// BusinessSearch makes a request given the options provided.
+func (c *client) BusinessSearch(ctx context.Context, bso *BusinessSearchOptions) (*BusinessSearchResults, error) {
+	if err := bso.Validate(); err != nil {
+		return nil, err
+	}
+	var respBody BusinessSearchResults
+	_, err := c.authedDo(ctx, http.MethodGet, businessSearchPath(bso), nil, nil, &respBody)
+	return &respBody, err
+}
+
+// businessSearchPath returns the business search path with parameters.
+func businessSearchPath(bso *BusinessSearchOptions) string {
+	return fmt.Sprintf("/v3/businesses/search?%s", bso.URLValues().Encode())
 }
 
 // Validate returns an error with deteails when BusinessSearchOptions are not valid.

--- a/yelp/locales.go
+++ b/yelp/locales.go
@@ -1,8 +1,18 @@
 package yelp
 
-// ValidLocales are the valid locales from the Yelp Fusion API. This list was pulled
+import "fmt"
+
+// ValidateLocale checks if the provided locale is one of Yelp's supported locales.
+func ValidateLocale(locale string) error {
+	if _, ok := validLocales[locale]; !ok {
+		return fmt.Errorf("Invalid locale provided: %s", locale)
+	}
+	return nil
+}
+
+// validLocales are the valid locales from the Yelp Fusion API. This list was pulled
 // from https://www.yelp.com/developers/documentation/v3/supported_locales.
-var ValidLocales = map[string]struct{}{
+var validLocales = map[string]struct{}{
 	"cs_CZ":  struct{}{},
 	"da_DK":  struct{}{},
 	"de_AT":  struct{}{},

--- a/yelp/locales_test.go
+++ b/yelp/locales_test.go
@@ -1,0 +1,13 @@
+package yelp
+
+import "testing"
+
+func TestValidateLocale(t *testing.T) {
+	t.Run("Valid locale", func(t *testing.T) {
+		assert(t, ValidateLocale("zh_TW") == nil, "Valid locale should not error")
+	})
+
+	t.Run("Invalid locale", func(t *testing.T) {
+		assert(t, ValidateLocale("Kanto") != nil, "Invalid locale should error")
+	})
+}

--- a/yelp/location.go
+++ b/yelp/location.go
@@ -14,6 +14,11 @@ type Location struct {
 	ZipCode        string   `json:"zip_code"`
 }
 
+// Region defines an area of the businesses.
+type Region struct {
+	Center Coordinates `json:"center"`
+}
+
 // Coordinates defines a location with Latitude and Longitude.
 type Coordinates struct {
 	Latitude  float64 `json:"latitude"`
@@ -26,14 +31,4 @@ func (c Coordinates) URLValues() url.Values {
 	vals.Add("latitude", FloatString(c.Latitude))
 	vals.Add("longitude", FloatString(c.Longitude))
 	return vals
-}
-
-// Region defines an area of the businesses.
-type Region struct {
-	Center Coordinates `json:"center"`
-}
-
-// URLValues returns Region as url.Values.
-func (r Region) URLValues() url.Values {
-	return r.Center.URLValues()
 }


### PR DESCRIPTION
* Move structs to top of the files (made consistent across files)
* Add in basic example for `BusinessSearch` and `GetBusiness` APIs
  * User can uncomment functions to try it out locally once they have an API key
  * Add `Makefile` command to run example (given an `api_key`)
* Small refactor for how Yelp supported locales are validated internally